### PR TITLE
fix bug # 23 "restore" command ignores "Error" in output and ends wit…

### DIFF
--- a/cloudshell/networking/cisco/command_actions/system_actions.py
+++ b/cloudshell/networking/cisco/command_actions/system_actions.py
@@ -118,7 +118,7 @@ class SystemActions(object):
                                              error_map=error_map,
                                              timeout=timeout,
                                              check_action_loop_detector=False).execute_command(path=path)
-            match_error = re.search(r'[Ee]rror.*$', output)
+            match_error = re.search(r'[Ee]rror.*', output, flags=re.DOTALL)
             if match_error:
                 error_str = match_error.group()
                 raise CommandExecutionException('Override_Running',


### PR DESCRIPTION
…h successful state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-networking-cisco/64)
<!-- Reviewable:end -->
