### PR TITLE
Fix dev requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,13 +2,4 @@ pre-commit
 tox
 tox-factor
 -r test_requirements.txt
--e git+https://github.com/QualiSystems/cloudshell-logging.git@dev#egg=cloudshell-logging
--e git+https://github.com/QualiSystems/cloudshell-shell-core.git@dev#egg=cloudshell-shell-core
--e git+https://github.com/QualiSystems/cloudshell-cli.git@dev#egg=cloudshell-cli
--e git+https://github.com/QualiSystems/cloudshell-snmp.git@dev#egg=cloudshell-snmp
--e git+https://github.com/QualiSystems/cloudshell-snmp-autoload.git@dev#egg=cloudshell-snmp-autoload
--e git+https://github.com/QualiSystems/cloudshell-shell-flows.git@dev#egg=cloudshell-shell-flows
--e git+https://github.com/QualiSystems/cloudshell-shell-connectivity-flow.git@dev#egg=cloudshell-shell-connectivity-flow
--e git+https://github.com/QualiSystems/cloudshell-shell-flows.git@dev#egg=cloudshell-shell-flows
--e git+https://github.com/QualiSystems/cloudshell-shell-standards.git@dev#egg=cloudshell-shell-standards
--e git+https://github.com/QualiSystems/cloudshell-shell-networking-standard.git@dev#egg=cloudshell-shell-networking-standard
+-r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ commands = pre-commit run --all-files --show-diff-on-failure
 [testenv:build]
 skip_install = true
 commands =
-    python setup.py sdist --format zip
-    python setup.py bdist_wheel --universal
+    python setup.py -q sdist --format zip
+    python setup.py -q bdist_wheel --universal
 
 [isort]
 line_length = 88


### PR DESCRIPTION
use default requirements for dev_requirements.txt
if you need to use not released requirements you can specify it individually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-networking-cisco/118)
<!-- Reviewable:end -->
